### PR TITLE
fix: bad code in Internal server error class

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -20,7 +20,7 @@ export type ElysiaErrors =
 	| ValidationError
 
 export class InternalServerError extends Error {
-	code = 'NOT_FOUND'
+	code = 'INTERNAL_SERVER_ERROR'
 	status = 500
 
 	constructor() {


### PR DESCRIPTION
This fixes issue when NotFoundError and InternalServerError has the same code 'NOT_FOUND'.